### PR TITLE
Fixed small bug when supplying bytes variable to MachO() object

### DIFF
--- a/machofile.py
+++ b/machofile.py
@@ -338,7 +338,7 @@ DYLIB_CMD_TYPES = two_way_dict(dylib_command_types)
 class MachO:
     """A Mach-O representation.
 
-    This class represents a Mach-O filif self.file_path is None:e, providing methods to parse it and
+    This class represents a Mach-O file, providing methods to parse it and
     access most of its structures and data.
 
     It expect to be supplied with either a file path or a data buffer to parse.

--- a/machofile.py
+++ b/machofile.py
@@ -338,7 +338,7 @@ DYLIB_CMD_TYPES = two_way_dict(dylib_command_types)
 class MachO:
     """A Mach-O representation.
 
-    This class represents a Mach-O file, providing methods to parse it and
+    This class represents a Mach-O filif self.file_path is None:e, providing methods to parse it and
     access most of its structures and data.
 
     It expect to be supplied with either a file path or a data buffer to parse.
@@ -371,6 +371,7 @@ class MachO:
             self.fh.close()
         else:
             self.data = data
+            self.file_path = None
 
         self.f = io.BytesIO(self.data)
 


### PR DESCRIPTION
If supplying only bytes buffer to MachO() object and running parse(), self.file_name was not properly initialized leading to:

>>> macho = MachO(data=binary_bytes)
>>> macho.parse()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "machofile.py", line 391, in parse
    self.general_info = self.get_general_info()
  File "machofile.py", line 425, in get_general_info
    if self.file_path is None:
AttributeError: 'MachO' object has no attribute 'file_path'

