### PR TITLE
bug: Parser infers FAT_CIGAM means FAT struct is little-endian, FAT struct should always be big-endian

### DIFF
--- a/machofile.py
+++ b/machofile.py
@@ -593,21 +593,11 @@ class UniversalMachO:
         magic = struct.unpack(">I", self.f.read(4))[0]
         nfat_arch = struct.unpack(">I", self.f.read(4))[0]
         
-        # Determine if we need to swap bytes
-        swap_bytes = magic in {FAT_CIGAM, FAT_CIGAM_64}
-        endian = "<" if swap_bytes else ">"
-        
-        if swap_bytes:
-            nfat_arch = struct.unpack("<I", struct.pack(">I", nfat_arch))[0]
-        
         # Read FAT arch entries
         for _ in range(nfat_arch):
             fat_arch_data = self.f.read(20)  # fat_arch is 20 bytes
             
-            if swap_bytes:
-                cputype, cpusubtype, offset, size, align = struct.unpack("<5I", fat_arch_data)
-            else:
-                cputype, cpusubtype, offset, size, align = struct.unpack(">5I", fat_arch_data)
+            cputype, cpusubtype, offset, size, align = struct.unpack(">5I", fat_arch_data)
             
             # Extract architecture name
             arch_name = self._get_arch_name(cputype, cpusubtype)


### PR DESCRIPTION
The parser currently assumes FAT_CIGAM magic infers little-endianness for FAT structures, causing a crash with a specially formatted MachO file. According to Apple's OS X documentation, FAT structures are always big endian: "Regardless of the content this data structure describes, all its fields are stored in big-endian byte order." (doc mirror: https://github.com/aidansteele/osx-abi-macho-file-format-reference).

This script generates a problematic MachO file which demonstrates the crash:
```
#!/usr/bin/env python3
import struct

# Create minimal Mach-O (32 bytes)
def make_macho():
    return struct.pack("<IIIIIIII", 0xFEEDFACF, 0x100000C, 0, 2, 0, 0, 0, 0) + b'\x00' * 24

data = bytearray()

# FAT header (FAT_CIGAM, 1 arch)
data.extend(struct.pack(">II", 0xBEBAFECA, 1))

# FAT arch entry (ARM64, offset=28, size=32)
data.extend(struct.pack(">IIIII", 0x100000C, 0, 28, 32, 0))

# Add Mach-O at offset 28
data.extend(make_macho())

# Write test file
with open("cigam_test.macho", "wb") as f:
    f.write(data)

print(f"Created cigam_test.macho ({len(data)} bytes)")
```

Output:
```
>python genfile.py
Created cigam_test.macho (84 bytes)

>python machofile.py -f cigam_test.macho -a
Traceback (most recent call last):
  File "C:\Users\damag\OneDrive\Desktop\machofile.py", line 3414, in <module>
    main()
  File "C:\Users\damag\OneDrive\Desktop\machofile.py", line 3088, in main
    macho = UniversalMachO(file_path=file_path)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\damag\OneDrive\Desktop\machofile.py", line 574, in __init__
    self._parse_fat_binary()
  File "C:\Users\damag\OneDrive\Desktop\machofile.py", line 608, in _parse_fat_binary
    cputype, cpusubtype, offset, size, align = struct.unpack("<5I", fat_arch_data)
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
struct.error: unpack requires a buffer of 20 bytes
```

With the fix applied:
```
>python fixed_machofile.py -f cigam_test.macho -a

[Universal Binary - Architectures: arm64]

[General File Info - arm64]
        Filename:    cigam_test.macho
        Filesize:    32
        MD5:         8e6bfc2af98b1e2994ad08bf16505c93
        SHA1:        0e75689240a69dd78aec028e4938f51683cf05e6
        SHA256:      79e4214b770ec982f202b553b1f70eaa9f1888135d7d4a341d378153fe193e6d

[Mach-O Header - arm64]
        magic:       MH_MAGIC_64 (64-bit), 0xFEEDFACF
        cputype:     ARM 64-bit
        cpusubtype:  ARM_ALL
        filetype:    EXECUTE
        ncmds:       0
        sizeofcmds:  0
        flags:       0

[Load Cmd table - arm64]
        No load commands found

[Load Commands - arm64]
        No load commands found

[File Segments - arm64]
        No segments found

[Dylib Commands - arm64]
        No dylib commands found

[Dylib Names - arm64]
        No dylib names found

[UUID - arm64]
        No uuid found

[Entry Point - arm64]
        No entry point found

[Version Information - arm64]
        No version information found

[Code Signature - arm64]
        signed:      False
        signing_status:Unsigned
        certificates_info:
            count:       0
            certificates:
        entitlements_info:
            count:       0
            entitlements:

[Imported Functions - arm64]
        <unknown>:

[Exported Symbols - arm64]
        <unknown>:

[Similarity Hashes - arm64]
        dylib_hash:  d41d8cd98f00b204e9800998ecf8427e
        import_hash: d41d8cd98f00b204e9800998ecf8427e
        export_hash: d41d8cd98f00b204e9800998ecf8427e
```

The fix removes the current swap_bytes parsing logic and always reads FAT structures as big-endian.